### PR TITLE
Add Pillow to pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ MarkupSafe==1.1.1
 numpy==1.19.2
 openpyxl==3.0.5
 pandas==1.1.2
+Pillow
 pylint==2.6.0
 toml==0.10.1
 Unidecode==1.1.1


### PR DESCRIPTION
#### Description:

Stepping throught the README.md's WORKFLOW steps failed on `python sheet1.py` with this error:
```python
$ python sheet1.py 
Traceback (most recent call last):
  File "sheet1.py", line 132, in <module>
    formuale_pic = Image("formulae.png")
  File "/usr/local/devel/MyWrk/geo-wrk/gravcalc-v2.0/venv-gravcalc/lib/python3.7/site-packages/openpyxl/drawing/image.py", line 32, in __init__
    image = _import_image(img)
  File "/usr/local/devel/MyWrk/geo-wrk/gravcalc-v2.0/venv-gravcalc/lib/python3.7/site-packages/openpyxl/drawing/image.py", line 13, in _import_image
    raise ImportError('You must install Pillow to fetch image objects')
```


Adding Pillow with `pip install Pillow` resolved the issued. So this change adds Pillow to the gravcalc-v2.0 requirements.txt.  

Another option, if the formulae.png is optional,  would be to use try/catch to catch the ImportError and ignore it.  If you prefer that solution, let me know and I'll make the change on this branch.  

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC




